### PR TITLE
Replace kind alpha version for latest stable

### DIFF
--- a/setup_devel_environment.yaml
+++ b/setup_devel_environment.yaml
@@ -101,7 +101,7 @@
 
     - name: Download latest kind version
       ansible.builtin.get_url:
-        url: "https://storage.googleapis.com/k8s-staging-kind/latest/kind-linux-amd64"
+        url: "https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64"
         dest: "$HOME/bin/kind"
         mode: u+x
 


### PR DESCRIPTION
I don't think it's a good idea to use the staging kind release (alpha), unless there is a good reason for it.
The downside is that I could not found a "generic" URL that would automatically update whenever there is a new stable release (https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 points to the alpha release as well).